### PR TITLE
fix: match Node flag semantics and parse lazily

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { envFlags, cliFlags } from './node-options.ts';
+import { getNodeFlags } from './node-options.ts';
 
 /**
  * ESM conditions
@@ -8,12 +8,11 @@ import { envFlags, cliFlags } from './node-options.ts';
  * https://github.com/nodejs/node/blob/v24.11.0/lib/internal/modules/helpers.js#L60-L76
  */
 export const getConditions = () => {
-	const noAddons = envFlags['no-addons'] || cliFlags['no-addons'];
+	const { conditions, addons } = getNodeFlags();
 	return [
 		'node',
 		...(process.features?.require_module ? ['module-sync'] : []),
-		...(noAddons ? [] : ['node-addons']),
-		...(envFlags.conditions ?? []),
-		...(cliFlags.conditions ?? []),
+		...(addons ? ['node-addons'] : []),
+		...(conditions ?? []),
 	];
 };

--- a/src/node-options.ts
+++ b/src/node-options.ts
@@ -1,9 +1,27 @@
 import { parseArgs } from 'node:util';
 import { tokenizeNodeOptions } from './tokenize-node-options-env.ts';
 
+/**
+ * Node treats `_` as interchangeable with `-` in option names
+ * (values are untouched):
+ * https://github.com/nodejs/node/blob/v24.15.0/src/node_options-inl.h#L369-L373
+ */
+const normalizeFlagName = (argument: string) => {
+	if (!argument.startsWith('--')) {
+		return argument;
+	}
+
+	const equalsIndex = argument.indexOf('=');
+	if (equalsIndex === -1) {
+		return argument.replaceAll('_', '-');
+	}
+
+	return argument.slice(0, equalsIndex).replaceAll('_', '-') + argument.slice(equalsIndex);
+};
+
 const parseNodeFlags = (args: string[]) => {
-	const { values } = parseArgs({
-		args,
+	const { values, tokens } = parseArgs({
+		args: args.map(normalizeFlagName),
 		options: {
 			// https://nodejs.org/api/cli.html#-c-condition---conditionscondition
 			conditions: {
@@ -13,16 +31,54 @@ const parseNodeFlags = (args: string[]) => {
 			},
 
 			// https://nodejs.org/api/cli.html#--no-addons
+			addons: { type: 'boolean' as const },
 			'no-addons': { type: 'boolean' as const },
 		},
 		strict: false,
 		allowPositionals: true,
+		tokens: true,
 	});
+
+	/**
+	 * Node ignores values on boolean flags (`--no-addons=false` still
+	 * disables addons) and the last flag wins (`--no-addons --addons`
+	 * keeps addons enabled):
+	 * https://github.com/nodejs/node/blob/v24.15.0/src/node_options-inl.h#L375-L380
+	 */
+	let addons = true;
+	for (const token of tokens) {
+		if (token.kind === 'option') {
+			if (token.name === 'addons') {
+				addons = true;
+			} else if (token.name === 'no-addons') {
+				addons = false;
+			}
+		}
+	}
+
 	return {
-		conditions: values.conditions as string[] | undefined,
-		'no-addons': values['no-addons'] as boolean | undefined,
+		// In non-strict mode, a valueless --conditions parses as a boolean
+		conditions: (
+			values.conditions as (string | boolean)[] | undefined
+		)?.filter((value): value is string => typeof value === 'string'),
+		addons,
 	};
 };
 
-export const envFlags = parseNodeFlags(tokenizeNodeOptions());
-export const cliFlags = parseNodeFlags(process.execArgv);
+let nodeFlags: ReturnType<typeof parseNodeFlags> | undefined;
+
+/**
+ * Parsed lazily on first access so importing this module has no
+ * side effects (e.g. node:util's parseArgs only exists in
+ * Node.js >=18.3.0)
+ *
+ * NODE_OPTIONS is processed before argv so argv flags win:
+ * https://github.com/nodejs/node/blob/v24.15.0/src/node.cc#L954-L967
+ */
+export const getNodeFlags = () => {
+	nodeFlags ??= parseNodeFlags([
+		...tokenizeNodeOptions(),
+		...process.execArgv,
+	]);
+	return nodeFlags;
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -17,6 +17,12 @@ for (const version of nodeVersions) {
 			import { getConditions } from '${getConditionsPath}';
 			console.log(JSON.stringify({ conditions: getConditions(), execArgv: process.execArgv }));
 			`,
+
+			'lazy.mjs': `
+			import { getConditions } from '${getConditionsPath}';
+			process.env.NODE_OPTIONS = '--conditions=set-after-import';
+			console.log(JSON.stringify(getConditions()));
+			`,
 		});
 		onFinish(() => fixture.rm());
 
@@ -62,6 +68,80 @@ for (const version of nodeVersions) {
 			const { conditions } = JSON.parse(stdout);
 
 			expect(conditions).not.toContain('node-addons');
+		});
+
+		test('--no_addons underscore alias excludes node-addons', async () => {
+			const nodeOptions = ['--no_addons'];
+
+			const { stdout } = await node([
+				...nodeOptions,
+				'file.mjs',
+			], { cwd: fixture.path });
+			const { conditions } = JSON.parse(stdout);
+
+			expect(conditions).not.toContain('node-addons');
+
+			const expected = await getNodeConditions(node, { nodeOptions });
+			expect(conditions).toStrictEqual(expected);
+		});
+
+		test('Boolean flag values are ignored (--no-addons=false still disables)', async () => {
+			const nodeOptions = ['--no-addons=false'];
+
+			const { stdout } = await node([
+				...nodeOptions,
+				'file.mjs',
+			], { cwd: fixture.path });
+			const { conditions } = JSON.parse(stdout);
+
+			expect(conditions).not.toContain('node-addons');
+
+			const expected = await getNodeConditions(node, { nodeOptions });
+			expect(conditions).toStrictEqual(expected);
+		});
+
+		test('Last addons flag wins (--no-addons --addons)', async () => {
+			const nodeOptions = ['--no-addons', '--addons'];
+
+			const { stdout } = await node([
+				...nodeOptions,
+				'file.mjs',
+			], { cwd: fixture.path });
+			const { conditions } = JSON.parse(stdout);
+
+			expect(conditions).toContain('node-addons');
+
+			const expected = await getNodeConditions(node, { nodeOptions });
+			expect(conditions).toStrictEqual(expected);
+		});
+
+		test('argv --addons overrides NODE_OPTIONS --no-addons', async () => {
+			const NODE_OPTIONS = '--no-addons';
+			const nodeOptions = ['--addons'];
+
+			const { stdout } = await node([
+				...nodeOptions,
+				'file.mjs',
+			], {
+				cwd: fixture.path,
+				env: { NODE_OPTIONS },
+			});
+			const { conditions } = JSON.parse(stdout);
+
+			expect(conditions).toContain('node-addons');
+
+			const expected = await getNodeConditions(node, {
+				nodeOptions,
+				NODE_OPTIONS,
+			});
+			expect(conditions).toStrictEqual(expected);
+		});
+
+		test('Flags are parsed lazily on first call', async () => {
+			const { stdout } = await node(['lazy.mjs'], { cwd: fixture.path });
+			const conditions = JSON.parse(stdout);
+
+			expect(conditions).toContain('set-after-import');
 		});
 
 		test('NODE_OPTIONS conditions come before argv conditions', async () => {


### PR DESCRIPTION
## Problem

Three gaps versus Node's actual flag handling, found while integrating get-conditions into tsx (privatenumber/tsx#239 fallback resolution):

1. **Eager parsing at import**: `envFlags`/`cliFlags` call `parseArgs` at module top-level. Consumers that bundle get-conditions into an always-loaded path crash on import where `node:util`'s `parseArgs` doesn't exist (< 18.3.0), even if they never call `getConditions()`.
2. **Underscore aliases missed**: Node treats `_` as interchangeable with `-` in option names ([`node_options-inl.h#L369-L373`](https://github.com/nodejs/node/blob/v24.15.0/src/node_options-inl.h#L369-L373)), so `--no_addons` disables addons — but `parseArgs` matches literal names and kept `node-addons`.
3. **Boolean negation semantics**: Node ignores values on boolean flags (`--no-addons=false` still disables) and the last flag wins (`--no-addons --addons` keeps addons; argv `--addons` overrides `NODE_OPTIONS=--no-addons` since NODE_OPTIONS is processed first, [`node.cc#L954-L967`](https://github.com/nodejs/node/blob/v24.15.0/src/node.cc#L954-L967)). The `envFlags['no-addons'] || cliFlags['no-addons']` OR could never re-enable, so `NODE_OPTIONS=--no-addons node --addons` wrongly dropped `node-addons`.

All three verified empirically against Node 24.15.0 / 22.22.3.

## Changes

- Flag parsing moved into a lazy, memoized `getNodeFlags()`; importing the module is now side-effect free.
- Flag names (only the part before `=`, only `--`-prefixed args) are normalized `_` → `-` before parsing; values are untouched (`--conditions=my_cond` stays `my_cond`).
- `--addons`/`--no-addons` are resolved by scanning parseArgs `tokens` in order over the combined `NODE_OPTIONS` + `execArgv` list, giving Node's ignore-value + last-flag-wins behavior across both sources. This replaces the per-source parse, which also simplifies `getConditions()`.
- Valueless `--conditions` (parses as boolean in non-strict mode) is filtered out instead of leaking a non-string into the result.
- New tests use the existing ground-truth harness (compared against Node's own `context.conditions`) for each behavior, plus a laziness test that mutates `NODE_OPTIONS` after import.

Note: the `tokens` parseArgs option requires Node ≥18.11; since parsing is now lazy this only affects callers actually invoking `getConditions()`, and the tested support floor (Node 20) is unchanged.